### PR TITLE
Design & content refresh: theme overhaul, SEO metadata, and i18n updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,45 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lucho Web | Expert Web Development</title>
+    <title>Lucho Web | Desarrollo Web, SEO y Landing Pages que convierten</title>
     <meta name="description"
-        content="Desarrollo web profesional, tiendas online, sitios empresariales y asesorías. Agencia Lucho Web Colombia." />
+        content="Desarrollo web estratégico en Colombia: landing pages, tiendas online y sitios SEO orientados a conversión para vender más y escalar tu negocio." />
     <meta name="keywords"
-        content="desarrollo web, landing pages, tiendas online, asesorías web, sitios institucionales, WooCommerce, Shopify, Colombia" />
+        content="desarrollo web Colombia, landing pages que convierten, SEO técnico, diseño UX UI, tiendas online, WooCommerce, Shopify" />
     <meta name="author" content="Lucho Web" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#020617" />
+    <link rel="canonical" href="https://luchoweb.dev/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_CO" />
+    <meta property="og:title" content="Lucho Web | Desarrollo Web y SEO orientado a resultados" />
+    <meta property="og:description"
+        content="Diseño y desarrollo web con enfoque comercial: sitios, SaaS y landing pages listas para convertir visitas en clientes." />
+    <meta property="og:url" content="https://luchoweb.dev/" />
+    <meta property="og:image" content="https://luchoweb.dev/me-site.jpeg" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Lucho Web | Desarrollo Web y SEO orientado a resultados" />
+    <meta name="twitter:description"
+        content="Sitios web modernos y estrategia digital para vender más con una experiencia de usuario impecable." />
+    <meta name="twitter:image" content="https://luchoweb.dev/me-site.jpeg" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "Lucho Web",
+        "url": "https://luchoweb.dev/",
+        "description": "Servicios de desarrollo web, UX/UI y SEO técnico orientados a conversión.",
+        "areaServed": "Colombia",
+        "sameAs": [
+          "https://www.linkedin.com/in/luchowebdev",
+          "https://github.com/luchoweb",
+          "https://www.tiktok.com/@luchoweb.dev"
+        ]
+      }
+    </script>
 </head>
 
 <body class="bg-[#0f0f0f] text-white">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ export default function App() {
       <Header />
       <Hero />
       <Services />
-      {/*<Work />*/}
+      <Work />
       <About />
       <Contact />
       <Footer />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -26,17 +26,17 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="relative bg-neutral-950 border-t border-neutral-800">
+    <footer className="relative bg-transparent border-t border-white/10">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-center justify-between gap-6 py-10 md:flex-row">
           {/* Brand + tagline */}
           <div className="text-center md:text-left">
             <div className="inline-flex items-center gap-2">
-              <span className="rounded-md bg-neutral-900 px-2 py-1 text-sm tracking-tight text-neutral-200 ring-1 ring-inset ring-neutral-800 font-mono">
+              <span className="rounded-md bg-white/5 px-2 py-1 text-sm tracking-tight text-slate-200 ring-1 ring-inset ring-white/15 font-mono">
                 {t("logo")}
               </span>
             </div>
-            <p className="mt-3 text-sm text-neutral-400 max-w-md">
+            <p className="mt-3 text-sm text-slate-400 max-w-md">
               {t("footer.tagline")}
             </p>
           </div>
@@ -47,7 +47,7 @@ export default function Footer() {
               href="https://www.linkedin.com/in/luchowebdev"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-900 ring-1 ring-inset ring-neutral-800 text-neutral-300 hover:bg-neutral-800"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-slate-300 hover:bg-white/10"
               aria-label={t("social.linkedin")}
               title={t("social.linkedin")}
             >
@@ -57,7 +57,7 @@ export default function Footer() {
               href="https://github.com/luchoweb"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-900 ring-1 ring-inset ring-neutral-800 text-neutral-300 hover:bg-neutral-800"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-slate-300 hover:bg-white/10"
               aria-label={t("social.github")}
               title={t("social.github")}
             >
@@ -67,7 +67,7 @@ export default function Footer() {
               href="https://www.tiktok.com/@luchoweb.dev"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-900 ring-1 ring-inset ring-neutral-800 text-neutral-300 hover:bg-neutral-800"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-slate-300 hover:bg-white/10"
               aria-label={t("social.tiktok")}
               title={t("social.tiktok")}
             >
@@ -76,8 +76,8 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className="border-t border-neutral-900 py-6">
-          <p className="text-center text-xs text-neutral-500">
+        <div className="border-t border-white/5 py-6">
+          <p className="text-center text-xs text-slate-500">
             &copy; {year} Lucho Web · {t("footer.rights")}
           </p>
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 const NAV = [
   { key: "home", href: "#home" },
   { key: "services", href: "#services" },
-  //{ key: "work", href: "#work" },
+  { key: "work", href: "#work" },
   { key: "about", href: "#about" },
   { key: "contact", href: "#contact" },
 ];
@@ -34,23 +34,25 @@ export default function Header() {
   }, [open]);
 
   const changeLang = (lng) => {
-      i18n.changeLanguage(lng);
+    i18n.changeLanguage(lng);
   };
 
   return (
     <header
       className={[
         "fixed inset-x-0 top-0 z-50",
-        "transition-colors",
-        "border-b border-neutral-800",
-        scrolled ? "bg-neutral-900/80 backdrop-blur" : "bg-transparent",
+        "transition-all duration-300",
+        "border-b border-white/10",
+        scrolled
+          ? "bg-slate-950/80 backdrop-blur-xl shadow-[0_8px_30px_rgba(0,0,0,0.35)]"
+          : "bg-transparent",
       ].join(" ")}
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <a href="#home" className="flex items-center gap-2 group">
-            <span className="rounded-md bg-neutral-900 px-2 py-1 text-sm tracking-tight text-neutral-200 ring-1 ring-inset ring-neutral-800 font-mono">
+            <span className="rounded-md bg-white/5 px-2 py-1 text-sm tracking-tight text-slate-100 ring-1 ring-inset ring-white/20 font-mono">
               {t("logo")}
             </span>
           </a>
@@ -61,7 +63,7 @@ export default function Header() {
               <a
                 key={item.href}
                 href={item.href}
-                className="px-3 py-2 text-sm text-neutral-300 hover:text-white hover:bg-neutral-800/60 rounded-md transition"
+                className="px-3 py-2 text-sm text-slate-300 hover:text-white hover:bg-white/10 rounded-md transition"
               >
                 {t(`nav.${item.key}`)}
               </a>
@@ -72,19 +74,19 @@ export default function Header() {
           <div className="hidden md:flex items-center gap-2">
             <button
               onClick={() => changeLang("en")}
-              className="inline-flex items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 px-2.5 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800"
+              className="inline-flex items-center justify-center rounded-lg border border-white/15 bg-white/5 px-2.5 py-1.5 text-xs text-slate-200 hover:bg-white/10"
             >
               EN
             </button>
             <button
               onClick={() => changeLang("es")}
-              className="inline-flex items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 px-2.5 py-1.5 text-xs text-neutral-300 hover:bg-neutral-800"
+              className="inline-flex items-center justify-center rounded-lg border border-white/15 bg-white/5 px-2.5 py-1.5 text-xs text-slate-200 hover:bg-white/10"
             >
               ES
             </button>
             <a
               href="#contact"
-              className="inline-flex items-center gap-2 rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-neutral-800 hover:border-neutral-600"
+              className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-100 shadow-sm transition hover:bg-cyan-400/20 hover:border-cyan-300/40"
             >
               <span>{t("cta.letsTalk")}</span>
             </a>
@@ -94,7 +96,7 @@ export default function Header() {
           <button
             aria-label={t("menu.open")}
             onClick={() => setOpen(true)}
-            className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-800 text-neutral-200 hover:bg-neutral-800/60"
+            className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-lg border border-white/15 text-slate-200 hover:bg-white/10"
           >
             <span className="sr-only">{t("menu.open")}</span>
             <div className="space-y-1.5">
@@ -117,7 +119,7 @@ export default function Header() {
         <div
           onClick={() => setOpen(false)}
           className={[
-            "absolute inset-0 bg-black/60",
+            "absolute inset-0 bg-slate-950/75 backdrop-blur-sm",
             open ? "opacity-100" : "opacity-0",
             "transition-opacity",
           ].join(" ")}
@@ -127,18 +129,18 @@ export default function Header() {
         <aside
           className={[
             "absolute right-0 top-0 h-dvh w-80 max-w-[85%]",
-            "bg-neutral-900 border-l border-neutral-800 shadow-xl",
+            "bg-slate-950 border-l border-white/10 shadow-xl",
             "transform transition-transform",
             open ? "translate-x-0" : "translate-x-full",
           ].join(" ")}
           aria-label={t("menu.title")}
         >
-          <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-800">
-            <span className="text-sm text-neutral-300">{t("menu.title")}</span>
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+            <span className="text-sm text-slate-300">{t("menu.title")}</span>
             <button
               aria-label={t("menu.close")}
               onClick={() => setOpen(false)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-neutral-800 text-neutral-300 hover:bg-neutral-800/60"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/15 text-slate-300 hover:bg-white/10"
             >
               <span className="sr-only">{t("menu.close")}</span>
               <svg
@@ -162,7 +164,7 @@ export default function Header() {
                 key={item.href}
                 href={item.href}
                 onClick={() => setOpen(false)}
-                className="block rounded-lg px-3 py-3 text-base text-neutral-200 hover:bg-neutral-800/70"
+                className="block rounded-lg px-3 py-3 text-base text-slate-200 hover:bg-white/10"
               >
                 {t(`nav.${item.key}`)}
               </a>
@@ -170,7 +172,7 @@ export default function Header() {
             <a
               href="#contact"
               onClick={() => setOpen(false)}
-              className="mt-2 block rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-3 text-base font-medium text-white hover:bg-neutral-800"
+              className="mt-2 block rounded-lg border border-cyan-400/30 bg-cyan-400/10 px-3 py-3 text-base font-medium text-cyan-50 hover:bg-cyan-400/20"
             >
               {t("cta.letsTalk")}
             </a>
@@ -179,13 +181,13 @@ export default function Header() {
             <div className="mt-4 flex items-center gap-2 px-3">
               <button
                 onClick={() => changeLang("en")}
-                className="rounded-md border border-neutral-800 px-3 py-1 text-sm text-neutral-300 hover:bg-neutral-800"
+                className="rounded-md border border-white/15 px-3 py-1 text-sm text-slate-300 hover:bg-white/10"
               >
                 EN
               </button>
               <button
                 onClick={() => changeLang("es")}
-                className="rounded-md border border-neutral-800 px-3 py-1 text-sm text-neutral-300 hover:bg-neutral-800"
+                className="rounded-md border border-white/15 px-3 py-1 text-sm text-slate-300 hover:bg-white/10"
               >
                 ES
               </button>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -17,16 +17,21 @@
   },
   "hero": {
     "badge": "{{years}} years of experience",
-    "title": "I solve problems; code and AI are just the tools",
-    "subtitle": "For {{years}} years I've taken ideas to the internet, designing solutions, building products, and shipping them. And I also use AI every day.",
-    "primaryCta": "Let's talk",
-    "secondaryCta": "See my work",
+    "title": "I turn ideas into digital assets that sell",
+    "subtitle": "I build landing pages, websites, and web products focused on outcomes: more leads, stronger brand trust, and better conversions in less time.",
+    "primaryCta": "I want more sales",
+    "secondaryCta": "See approach & cases",
     "imagePlaceholder": "Your studio photo here",
-    "imageAlt": "Studio portrait of Lucho (placeholder)"
+    "imageAlt": "Studio portrait of Lucho (placeholder)",
+    "proof": {
+      "delivery": "First delivery in 7-14 days",
+      "focus": "Conversion-focused UX + technical SEO",
+      "roi": "Decisions backed by metrics"
+    }
   },
   "services": {
-    "title": "Services",
-    "subtitle": "Tailored digital solutions to bring ideas to life and strengthen your online presence.",
+    "title": "Services built for growth",
+    "subtitle": "Business-oriented web design and development: strategic clarity, strong UX, and high-quality technical execution.",
     "items": {
       "customDev": {
         "title": "Custom Web Development",
@@ -52,29 +57,49 @@
         "title": "Personalized Programming Classes",
         "desc": "Hands-on mentorship tailored to your level, using real projects and modern tools."
       }
-    }
+    },
+    "eyebrow": "Core offering"
   },
   "work": {
-    "title": "Work",
-    "subtitle": "Selected projects where I solved real problems and shipped ideas to the internet.",
+    "title": "Results and selected work",
+    "subtitle": "Examples of solutions built to increase sales, scale operations, and strengthen each brand’s online presence.",
     "thumbnailPlaceholder": "Project thumbnail",
     "viewProject": "View project",
     "items": {
-      "proj1": { "title": "Project A — OTT Streaming", "desc": "Modular frontend for an OTT platform with custom player and analytics." },
-      "proj2": { "title": "Project B — B2C E-commerce", "desc": "Shopify store tuned for conversions with payments and newsletter integrations." },
-      "proj3": { "title": "Project C — Quotation SaaS", "desc": "Multi-tenant app with auth, PDF generation, and fast quote delivery." },
-      "proj4": { "title": "Project D — Launch Landing", "desc": "High-performance landing page focused on conversions and waitlist growth." },
-      "proj5": { "title": "Project E — Admin Dashboard", "desc": "Real-time metrics, role management, and clean UX for operations." },
-      "proj6": { "title": "Project F — Corporate Site", "desc": "Custom site with CMS and technical SEO ready to scale." }
-    }
+      "proj1": {
+        "title": "Project A — OTT Streaming",
+        "desc": "Modular frontend for an OTT platform with custom player and analytics."
+      },
+      "proj2": {
+        "title": "Project B — B2C E-commerce",
+        "desc": "Shopify store tuned for conversions with payments and newsletter integrations."
+      },
+      "proj3": {
+        "title": "Project C — Quotation SaaS",
+        "desc": "Multi-tenant app with auth, PDF generation, and fast quote delivery."
+      },
+      "proj4": {
+        "title": "Project D — Launch Landing",
+        "desc": "High-performance landing page focused on conversions and waitlist growth."
+      },
+      "proj5": {
+        "title": "Project E — Admin Dashboard",
+        "desc": "Real-time metrics, role management, and clean UX for operations."
+      },
+      "proj6": {
+        "title": "Project F — Corporate Site",
+        "desc": "Custom site with CMS and technical SEO ready to scale."
+      }
+    },
+    "eyebrow": "Social proof"
   },
   "about": {
-    "title": "About Me",
-    "intro": "I'm Luis Rodríguez, known as Lucho Web. I've been a web developer for 14 years, helping companies and entrepreneurs bring ideas to life online.",
+    "title": "Your digital growth partner",
+    "intro": "I’m Luis Rodríguez (Lucho Web). For 14 years, I’ve helped companies and founders launch and optimize digital products with a commercial mindset.",
     "experience": "I began as a PHP developer, then shifted toward the Frontend world. After 9+ years working with WordPress, I built a strong full-stack profile.",
     "modern": "In the last 5 years, I've worked with modern stacks like React, Node, and Vue, following agile methodologies, using Git version control, and embracing clean scalable code practices.",
     "ai": "And these last two years have been the best. I have incorporated AI into my daily routine and have managed to improve my code, but also my development, deployment, and delivery times. AI has boosted my performance threefold.",
-    "highlightsTitle": "A few milestones along the way",
+    "highlightsTitle": "What I bring to your project",
     "highlights": {
       "fullstack": "Over a decade of full-stack development and complex custom builds.",
       "tech": "Experience with React, Node, Vue, PHP, and the WordPress ecosystem.",
@@ -83,8 +108,8 @@
     }
   },
   "contact": {
-    "title": "Contact",
-    "subtitle": "Have an idea or a technical challenge? Let's talk and define a clear path forward.",
+    "title": "Ready for your next digital version?",
+    "subtitle": "Share your business goal and I’ll propose a clear execution roadmap, timeline, and scope from the first conversation.",
     "call": {
       "title": "Direct call",
       "desc": "Let's speak now and review your case.",
@@ -106,14 +131,14 @@
       "body": "Hi Lucho, I'd like to discuss..."
     },
     "points": {
-      "response": "Get a fast reply according to project size.",
-      "discovery": "Focused discovery call to understand your goal.",
-      "ethics": "Transparent scope, timelines, and costs."
+      "response": "Initial response in less than 24 business hours.",
+      "discovery": "Discovery call focused on business outcomes.",
+      "ethics": "Clear scope, timeline, and pricing from day one."
     },
     "note": "Clicking a button will open your default app (phone, WhatsApp, or email)."
   },
   "footer": {
-    "tagline": "Beyond code, I build results.",
+    "tagline": "Design, technology, and strategy to turn visitors into customers.",
     "rights": "All rights reserved."
   },
   "social": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -17,16 +17,21 @@
   },
   "hero": {
     "badge": "{{years}} años de experiencia",
-    "title": "Resuelvo problemas; el código y la IA son mis herramientas",
-    "subtitle": "Durante {{years}} años he llevado ideas a internet: diseño soluciones, construyo productos y los pongo a producir. Y también uso IA todos los días.",
-    "primaryCta": "Hablemos",
-    "secondaryCta": "Ver trabajo",
+    "title": "Transformo ideas en activos digitales que venden",
+    "subtitle": "Creo landing pages, sitios y productos web orientados a resultados: más leads, más confianza de marca y mejores conversiones en menos tiempo.",
+    "primaryCta": "Quiero vender más",
+    "secondaryCta": "Ver casos y enfoque",
     "imagePlaceholder": "Tu foto de estudio aquí",
-    "imageAlt": "Retrato de estudio de Lucho (placeholder)"
+    "imageAlt": "Retrato de estudio de Lucho (placeholder)",
+    "proof": {
+      "delivery": "Entrega inicial en 7-14 días",
+      "focus": "Enfoque en conversión y SEO técnico",
+      "roi": "Decisiones guiadas por métricas"
+    }
   },
   "services": {
-    "title": "Servicios",
-    "subtitle": "Soluciones diseñadas a medida para impulsar tu presencia digital y hacer realidad tus ideas.",
+    "title": "Servicios para crecer online",
+    "subtitle": "Diseño y desarrollo web con visión de negocio: claridad estratégica, experiencia de usuario y ejecución técnica impecable.",
     "items": {
       "customDev": {
         "title": "Desarrollo web a la medida",
@@ -52,29 +57,49 @@
         "title": "Clases personalizadas de programación",
         "desc": "Formación práctica y guiada, adaptada a tu nivel, con proyectos reales y herramientas modernas."
       }
-    }
+    },
+    "eyebrow": "Oferta principal"
   },
   "work": {
-    "title": "Trabajo",
-    "subtitle": "Una selección de proyectos donde resolví problemas reales y llevé ideas a internet.",
+    "title": "Resultados y proyectos",
+    "subtitle": "Ejemplos de soluciones construidas para vender, escalar operaciones y mejorar la presencia digital de cada marca.",
     "thumbnailPlaceholder": "Miniatura del proyecto",
     "viewProject": "Ver proyecto",
     "items": {
-      "proj1": { "title": "Proyecto A — Streaming OTT", "desc": "Frontend modular para plataforma OTT con reproductor custom y analítica." },
-      "proj2": { "title": "Proyecto B — E-commerce B2C", "desc": "Tienda optimizada en Shopify con integraciones de pagos y newsletter." },
-      "proj3": { "title": "Proyecto C — SaaS de cotizaciones", "desc": "App multi-tenant con autenticación, PDF y envío de cotizaciones en minutos." },
-      "proj4": { "title": "Proyecto D — Landing de lanzamiento", "desc": "Landing de alto rendimiento enfocada en conversión y lista de espera." },
-      "proj5": { "title": "Proyecto E — Dashboard Admin", "desc": "Panel con métricas en tiempo real y control de usuarios/roles." },
-      "proj6": { "title": "Proyecto F — Sitio corporativo", "desc": "Sitio a medida con CMS y SEO técnico listo para escalar." }
-    }
+      "proj1": {
+        "title": "Proyecto A — Streaming OTT",
+        "desc": "Frontend modular para plataforma OTT con reproductor custom y analítica."
+      },
+      "proj2": {
+        "title": "Proyecto B — E-commerce B2C",
+        "desc": "Tienda optimizada en Shopify con integraciones de pagos y newsletter."
+      },
+      "proj3": {
+        "title": "Proyecto C — SaaS de cotizaciones",
+        "desc": "App multi-tenant con autenticación, PDF y envío de cotizaciones en minutos."
+      },
+      "proj4": {
+        "title": "Proyecto D — Landing de lanzamiento",
+        "desc": "Landing de alto rendimiento enfocada en conversión y lista de espera."
+      },
+      "proj5": {
+        "title": "Proyecto E — Dashboard Admin",
+        "desc": "Panel con métricas en tiempo real y control de usuarios/roles."
+      },
+      "proj6": {
+        "title": "Proyecto F — Sitio corporativo",
+        "desc": "Sitio a medida con CMS y SEO técnico listo para escalar."
+      }
+    },
+    "eyebrow": "Prueba social"
   },
   "about": {
-    "title": "Sobre mí",
-    "intro": "Soy Luis Rodríguez, conocido como Lucho Web. Llevo 14 años en el desarrollo web, trabajando para diversas compañías y ayudando a llevar ideas a internet.",
+    "title": "Tu aliado digital",
+    "intro": "Soy Luis Rodríguez (Lucho Web). Llevo 14 años ayudando a empresas y emprendedores a lanzar y optimizar productos digitales con enfoque comercial.",
     "experience": "Mis inicios fueron como desarrollador PHP, y con el tiempo evolucioné hacia el Frontend. Durante más de 9 años he trabajado con WordPress, forjando un perfil sólido como desarrollador full-stack.",
     "modern": "En los últimos 5 años he trabajado con tecnologías modernas como React, Node y Vue, aplicando metodologías ágiles, control de versiones con Git y buenas prácticas que garantizan calidad y escalabilidad.",
     "ai": "Y estos últimos 2 años han sido los mejores, he incorporado la IA en mi día a día y he logrado mejorar mi código, pero también mis tiempos de desarrollo, despliegue y entrega. La IA me ha potenciado 3x mi rendimiento.",
-    "highlightsTitle": "Algunos hitos de mi recorrido",
+    "highlightsTitle": "Lo que aporto a tu proyecto",
     "highlights": {
       "fullstack": "Más de una década desarrollando proyectos full-stack y personalizaciones complejas.",
       "tech": "Experiencia con React, Node, Vue, PHP, y ecosistemas WordPress.",
@@ -83,8 +108,8 @@
     }
   },
   "contact": {
-    "title": "Contacto",
-    "subtitle": "¿Tienes una idea o un reto técnico? Conversemos y encuentre una ruta clara para avanzar.",
+    "title": "¿Listo para tu siguiente versión digital?",
+    "subtitle": "Cuéntame tu objetivo comercial y te propongo una ruta clara de ejecución, tiempos y alcance desde la primera conversación.",
     "call": {
       "title": "Llamada directa",
       "desc": "Hablemos ahora mismo y revisemos tu caso.",
@@ -106,14 +131,14 @@
       "body": "Hola Lucho, me gustaría conversar sobre..."
     },
     "points": {
-      "response": "Respuesta rápida segun el tamaño del proyecto.",
-      "discovery": "Primera llamada de descubrimiento enfocada en objetivos.",
-      "ethics": "Transparencia en alcance, tiempos y costos."
+      "response": "Respuesta inicial en menos de 24 horas hábiles.",
+      "discovery": "Llamada de descubrimiento con foco en objetivos de negocio.",
+      "ethics": "Alcance, tiempos y costos claros desde el inicio."
     },
     "note": "Al hacer clic se abrirá tu app predeterminada (teléfono, WhatsApp o correo)."
   },
-   "footer": {
-    "tagline": "Más que escribir código, construyo resultados.",
+  "footer": {
+    "tagline": "Diseño, tecnología y estrategia para convertir visitas en clientes.",
     "rights": "Todos los derechos reservados."
   },
   "social": {

--- a/src/index.css
+++ b/src/index.css
@@ -9,4 +9,18 @@ html {
 body {
   font-family: "Inter Variable", sans-serif;
   font-weight: 300;
+  background:
+    radial-gradient(1400px 700px at 10% -10%, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(1100px 600px at 90% 0%, rgba(139, 92, 246, 0.14), transparent 55%),
+    #020617;
+  color: #e5e7eb;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+::selection {
+  background-color: rgba(56, 189, 248, 0.35);
+  color: #f8fafc;
 }

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -20,18 +20,18 @@ export default function About({ years = 14 }) {
   const { t } = useTranslation();
 
   return (
-    <section id="about" className="relative bg-neutral-950 py-20 sm:py-24">
+    <section id="about" className="relative bg-transparent py-20 sm:py-24">
       {/* decorative gradient */}
       <div
         aria-hidden
-        className="pointer-events-none absolute -left-24 top-0 h-72 w-72 rounded-full bg-purple-600/10 blur-3xl"
+        className="pointer-events-none absolute -left-24 top-0 h-72 w-72 rounded-full bg-indigo-500/15 blur-3xl"
       />
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid items-start gap-10 lg:grid-cols-12">
           {/* Left: narrative */}
           <div className="lg:col-span-7">
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-900 px-3 py-1 text-xs text-neutral-300">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-200">
               <span>
                 {t("hero.badge", { years })}
               </span>
@@ -39,7 +39,7 @@ export default function About({ years = 14 }) {
             <h2 className="text-3xl font-semibold text-white sm:text-4xl">
               {t("about.title")}
             </h2>
-            <div className="mt-5 space-y-6 text-neutral-300 leading-relaxed">
+            <div className="mt-5 space-y-6 text-slate-300 leading-relaxed">
               <p>{t("about.intro")}</p>
               <p>{t("about.experience")}</p>
               <p>{t("about.modern")}</p>
@@ -49,51 +49,51 @@ export default function About({ years = 14 }) {
 
           {/* Right: highlight card */}
           <div className="lg:col-span-5">
-            <div className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl">
+            <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-slate-900/60 p-6 shadow-2xl backdrop-blur-sm">
               <div
                 aria-hidden
-                className="pointer-events-none absolute -right-16 -top-16 h-40 w-40 rounded-full bg-indigo-500/10 blur-2xl"
+                className="pointer-events-none absolute -right-16 -top-16 h-40 w-40 rounded-full bg-cyan-500/10 blur-2xl"
               />
               <h3 className="text-lg font-medium text-white">
                 {t("about.highlightsTitle")}
               </h3>
-              <div className="mt-4 divide-y divide-neutral-800">
+              <div className="mt-4 divide-y divide-white/10">
                 <div className="flex gap-3 py-4">
-                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-neutral-300">
+                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-cyan-200">
                     {Icons.fullstack({ className: "h-5 w-5" })}
                   </span>
-                  <p className="text-sm text-neutral-300 flex-1">
+                  <p className="text-sm text-slate-300 flex-1">
                     {t("about.highlights.fullstack")}
                   </p>
                 </div>
                 <div className="flex gap-3 py-4">
-                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-neutral-300">
+                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-cyan-200">
                     {Icons.tech({ className: "h-5 w-5" })}
                   </span>
-                  <p className="text-sm text-neutral-300 flex-1">
+                  <p className="text-sm text-slate-300 flex-1">
                     {t("about.highlights.tech")}
                   </p>
                 </div>
                 <div className="flex gap-3 py-4">
-                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-neutral-300">
+                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-cyan-200">
                     {Icons.methodologies({ className: "h-5 w-5" })}
                   </span>
-                  <p className="text-sm text-neutral-300 flex-1">
+                  <p className="text-sm text-slate-300 flex-1">
                     {t("about.highlights.methodologies")}
                   </p>
                 </div>
                 <div className="flex gap-3 py-4">
-                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-neutral-300">
+                  <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/15 text-cyan-200">
                     {Icons.evolution({ className: "h-5 w-5" })}
                   </span>
-                  <p className="text-sm text-neutral-300 flex-1">
+                  <p className="text-sm text-slate-300 flex-1">
                     {t("about.highlights.evolution")}
                   </p>
                 </div>
               </div>
 
               {/* subtle footer note */}
-              <div className="mt-4 rounded-lg bg-neutral-950/60 p-3 text-xs text-neutral-400 ring-1 ring-inset ring-neutral-800">
+              <div className="mt-4 rounded-lg bg-white/5 p-3 text-xs text-slate-400 ring-1 ring-inset ring-white/10">
                 {t("hero.subtitle", { years })}
               </div>
             </div>

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -49,11 +49,11 @@ export default function Contact() {
   )}&body=${encodeURIComponent(t('contact.email.body'))}`;
 
   return (
-    <section id="contact" className="relative bg-neutral-950 py-20 sm:py-24">
+    <section id="contact" className="relative bg-transparent py-20 sm:py-24">
       {/* subtle background accent */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 -top-10 mx-auto h-56 w-56 rounded-full bg-emerald-600/10 blur-3xl"
+        className="pointer-events-none absolute inset-x-0 -top-10 mx-auto h-56 w-56 rounded-full bg-cyan-500/10 blur-3xl"
       />
 
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
@@ -61,30 +61,30 @@ export default function Contact() {
           <h2 className="text-3xl font-semibold text-white sm:text-4xl">
             {t("contact.title")}
           </h2>
-          <p className="mt-3 text-neutral-400 max-w-2xl mx-auto">
+          <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
             {t("contact.subtitle")}
           </p>
         </div>
 
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {/* Call */}
-          <div className="rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl flex justify-between flex-col">
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-6 shadow-2xl backdrop-blur-sm flex justify-between flex-col">
             <div className="flex items-center gap-3">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-emerald-400">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/10 text-emerald-300">
                 {Icon.phone({ className: "h-5 w-5" })}
               </span>
               <div className="flex-1">
                 <h3 className="text-base font-medium text-white">
                   {t("contact.call.title")}
                 </h3>
-                <p className="text-sm text-neutral-400">
+                <p className="text-sm text-slate-400">
                   {t("contact.call.desc")}
                 </p>
               </div>
             </div>
             <a
               href={`tel:+${PHONE_E164}`}
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-700 bg-emerald-700/20 px-4 py-2.5 text-sm font-medium text-emerald-200 hover:bg-emerald-700/30"
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2.5 text-sm font-medium text-emerald-100 hover:bg-emerald-400/20"
             >
               {Icon.phone({ className: "h-4 w-4" })}
               <span className="flex-1">
@@ -94,16 +94,16 @@ export default function Contact() {
           </div>
 
           {/* WhatsApp */}
-          <div className="rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl flex justify-between flex-col">
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-6 shadow-2xl backdrop-blur-sm flex justify-between flex-col">
             <div className="flex items-center gap-3">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-emerald-400">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/10 text-emerald-300">
                 {Icon.whatsapp({ className: "h-5 w-5" })}
               </span>
               <div className="flex-1">
                 <h3 className="text-base font-medium text-white">
                   {t("contact.whatsapp.title")}
                 </h3>
-                <p className="text-sm text-neutral-400">
+                <p className="text-sm text-slate-400">
                   {t("contact.whatsapp.desc")}
                 </p>
               </div>
@@ -112,7 +112,7 @@ export default function Contact() {
               href={WHATSAPP_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-700 bg-emerald-700/20 px-4 py-2.5 text-sm font-medium text-emerald-200 hover:bg-emerald-700/30"
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2.5 text-sm font-medium text-emerald-100 hover:bg-emerald-400/20"
             >
               {Icon.whatsapp({ className: "h-4 w-4" })}
               <span className="flex-1">
@@ -122,23 +122,23 @@ export default function Contact() {
           </div>
 
           {/* Email */}
-          <div className="rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl flex justify-between flex-col">
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-6 shadow-2xl backdrop-blur-sm flex justify-between flex-col">
             <div className="flex items-center gap-3">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-sky-400">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 ring-1 ring-inset ring-white/10 text-sky-300">
                 {Icon.mail({ className: "h-5 w-5" })}
               </span>
               <div className="flex-1">
                 <h3 className="text-base font-medium text-white">
                   {t("contact.email.title")}
                 </h3>
-                <p className="text-sm text-neutral-400">
+                <p className="text-sm text-slate-400">
                   {t("contact.email.desc")}
                 </p>
               </div>
             </div>
             <a
               href={MAILTO_URL}
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-sky-700 bg-sky-700/20 px-4 py-2.5 text-sm font-medium text-sky-200 hover:bg-sky-700/30 basis-full"
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-sky-400/30 bg-sky-400/10 px-4 py-2.5 text-sm font-medium text-sky-100 hover:bg-sky-400/20 basis-full"
             >
               {Icon.mail({ className: "h-4 w-4" })}
               <span className="flex-1">
@@ -157,17 +157,17 @@ export default function Contact() {
           ].map((text, i) => (
             <div
               key={i}
-              className="flex items-center gap-3 rounded-xl border border-neutral-800 bg-neutral-900 p-4"
+              className="flex items-center gap-3 rounded-xl border border-white/10 bg-slate-900/60 p-4"
             >
-              <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-emerald-400">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-white/5 ring-1 ring-inset ring-white/10 text-emerald-300">
                 {Icon.check({ className: "h-4 w-4" })}
               </span>
-              <p className="text-sm text-neutral-300 flex-1">{text}</p>
+              <p className="text-sm text-slate-300 flex-1">{text}</p>
             </div>
           ))}
         </div>
 
-        <p className="mt-8 text-center text-xs text-neutral-500">
+        <p className="mt-8 text-center text-xs text-slate-500">
           {t("contact.note")}
         </p>
       </div>

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -2,53 +2,73 @@ import { useTranslation } from "react-i18next";
 
 export default function Hero({ years = 14 }) {
   const { t } = useTranslation();
+  const proof = [
+    t("hero.proof.delivery"),
+    t("hero.proof.focus"),
+    t("hero.proof.roi"),
+  ];
 
   return (
-    <section id="home" className="relative overflow-hidden bg-neutral-950">
+    <section id="home" className="relative overflow-hidden bg-transparent">
       {/* Decorative glow */}
       <div
         aria-hidden
-        className="pointer-events-none absolute -top-24 right-[-20%] h-96 w-[60%] rounded-full bg-purple-600/10 blur-3xl"
+        className="pointer-events-none absolute -top-20 right-[-20%] h-[30rem] w-[65%] rounded-full bg-cyan-500/15 blur-3xl"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 bottom-0 h-80 w-80 rounded-full bg-fuchsia-500/10 blur-3xl"
       />
 
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid items-center gap-10 py-20 lg:grid-cols-2 lg:py-28">
           {/* Copy */}
           <div>
-            <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-900 px-3 py-1 text-xs text-neutral-300">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs text-slate-200 backdrop-blur">
               <span>{t("hero.badge", { years })}</span>
             </div>
             <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl md:text-6xl">
               {t("hero.title")}
             </h1>
-            <p className="mt-5 max-w-xl text-base leading-relaxed text-neutral-300 md:text-lg">
+            <p className="mt-5 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
               {t("hero.subtitle", { years })}
             </p>
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <a
                 href="#contact"
-                className="inline-flex items-center justify-center rounded-xl border border-neutral-700 bg-neutral-900 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-neutral-800 hover:border-neutral-600"
+                className="inline-flex items-center justify-center rounded-xl border border-cyan-400/30 bg-cyan-400/10 px-5 py-2.5 text-sm font-medium text-cyan-100 shadow-sm transition hover:bg-cyan-400/20 hover:border-cyan-300/40"
               >
                 {t("hero.primaryCta")}
               </a>
-              {/*<a
+              <a
                 href="#work"
-                className="inline-flex items-center justify-center rounded-xl border border-neutral-800 bg-neutral-950 px-5 py-2.5 text-sm font-medium text-neutral-200 transition hover:bg-neutral-900"
+                className="inline-flex items-center justify-center rounded-xl border border-white/20 bg-white/5 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
               >
                 {t("hero.secondaryCta")}
-              </a>*/}
+              </a>
+            </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+              {proof.map((item) => (
+                <p
+                  key={item}
+                  className="rounded-xl border border-white/10 bg-slate-900/50 px-3 py-2 text-xs text-slate-300"
+                >
+                  {item}
+                </p>
+              ))}
             </div>
           </div>
 
           {/* Placeholder image */}
           <div className="relative mx-auto w-full max-w-md">
-            <div className="relative aspect-[4/5] w-full overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900 shadow-2xl">
-              <div className="absolute inset-0 bg-gradient-to-br from-neutral-900 via-neutral-900 to-neutral-800" />
+            <div className="relative aspect-[4/5] w-full overflow-hidden rounded-3xl border border-white/15 bg-slate-900/70 shadow-[0_20px_60px_rgba(0,0,0,0.45)] backdrop-blur">
+              <div className="absolute inset-0 bg-gradient-to-br from-slate-900/50 via-slate-950/50 to-slate-900/50" />
               <div className="relative z-10 flex h-full w-full items-center justify-center">
-                <img src="/me-site.jpeg" alt="me" className="h-full" />
+                <img src="/me-site.jpeg" alt="me" className="h-full w-full object-cover" />
               </div>
-              <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-inset ring-neutral-800" />
+              <div className="pointer-events-none absolute inset-0 rounded-3xl ring-1 ring-inset ring-white/10" />
             </div>
           </div>
         </div>

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -22,13 +22,16 @@ export default function Services() {
   const { t } = useTranslation();
 
   return (
-    <section id="services" className="relative bg-neutral-950 py-20 sm:py-24">
+    <section id="services" className="relative bg-transparent py-20 sm:py-24">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-14">
+          <span className="inline-flex rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-cyan-100">
+            {t("services.eyebrow")}
+          </span>
           <h2 className="text-3xl font-semibold text-white sm:text-4xl">
             {t("services.title")}
           </h2>
-          <p className="mt-3 text-neutral-400 max-w-2xl mx-auto">
+          <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
             {t("services.subtitle")}
           </p>
         </div>
@@ -37,17 +40,17 @@ export default function Services() {
           {services.map(({ key, icon }) => (
             <div
               key={key}
-              className="rounded-2xl border border-neutral-800 bg-neutral-900 p-6 text-center transition hover:border-neutral-700 hover:bg-neutral-800/70"
+              className="rounded-2xl border border-white/10 bg-slate-900/55 p-6 text-center transition backdrop-blur-sm hover:-translate-y-1 hover:border-cyan-300/40 hover:bg-slate-900/75"
             >
               <div className="mb-4 flex items-center justify-center">
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-neutral-950 ring-1 ring-inset ring-neutral-800 text-neutral-300">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-white/5 ring-1 ring-inset ring-white/15 text-cyan-200">
                   {icon}
                 </span>
               </div>
               <h3 className="text-lg font-medium text-white mb-2">
                 {t(`services.items.${key}.title`)}
               </h3>
-              <p className="text-sm text-neutral-400 leading-relaxed">
+              <p className="text-sm text-slate-300 leading-relaxed">
                 {t(`services.items.${key}.desc`)}
               </p>
             </div>

--- a/src/sections/Work.jsx
+++ b/src/sections/Work.jsx
@@ -13,13 +13,16 @@ export default function Work() {
   const { t } = useTranslation();
 
   return (
-    <section id="work" className="relative bg-neutral-950 py-20 sm:py-24">
+    <section id="work" className="relative bg-transparent py-20 sm:py-24">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-12 text-center">
+          <span className="inline-flex rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-cyan-100">
+            {t("work.eyebrow")}
+          </span>
           <h2 className="text-3xl font-semibold text-white sm:text-4xl">
             {t("work.title")}
           </h2>
-          <p className="mt-3 text-neutral-400 max-w-2xl mx-auto">
+          <p className="mt-3 text-slate-300 max-w-2xl mx-auto">
             {t("work.subtitle")}
           </p>
         </div>
@@ -28,20 +31,20 @@ export default function Work() {
           {items.map(({ key }) => (
             <article
               key={key}
-              className="group overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-900 transition hover:border-neutral-700"
+              className="group overflow-hidden rounded-2xl border border-white/10 bg-slate-900/55 backdrop-blur-sm transition hover:-translate-y-1 hover:border-cyan-300/40"
             >
               {/* Thumbnail placeholder — replace with <img src=... alt=... /> */}
-              <div className="relative aspect-[16/10] w-full overflow-hidden bg-neutral-950">
-                <div className="absolute inset-0 bg-gradient-to-br from-neutral-900 via-neutral-900 to-neutral-800" />
+              <div className="relative aspect-[16/10] w-full overflow-hidden bg-slate-950/60">
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-900/60 via-slate-950/60 to-slate-900/60" />
                 <div className="relative z-10 flex h-full items-center justify-center">
                   <div className="text-center">
-                    <div className="mx-auto mb-3 h-14 w-14 rounded-lg border border-neutral-800 bg-neutral-950" />
-                    <p className="text-xs text-neutral-500">
+                    <div className="mx-auto mb-3 h-14 w-14 rounded-lg border border-white/15 bg-white/5" />
+                    <p className="text-xs text-slate-500">
                       {t("work.thumbnailPlaceholder")}
                     </p>
                   </div>
                 </div>
-                <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-neutral-800/80" />
+                <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-white/10" />
               </div>
 
               {/* Copy */}
@@ -49,7 +52,7 @@ export default function Work() {
                 <h3 className="text-base font-medium text-white">
                   {t(`work.items.${key}.title`)}
                 </h3>
-                <p className="mt-2 text-sm leading-relaxed text-neutral-400">
+                <p className="mt-2 text-sm leading-relaxed text-slate-300">
                   {t(`work.items.${key}.desc`)}
                 </p>
 


### PR DESCRIPTION
### Motivation
- Modernize the site's visual theme and improve contrast, spacing and depth using updated Tailwind utilities and global CSS. 
- Improve SEO and social sharing by adding canonical, Open Graph, Twitter cards, robots meta and structured data (JSON-LD). 
- Refocus site copy toward commercial outcomes and add richer bilingual content and UI microcopy for better conversion signals.

### Description
- Updated `index.html` with a new title, description, keywords, `canonical`, `robots`, `theme-color`, Open Graph and Twitter meta tags, and a `application/ld+json` ProfessionalService schema. 
- Global CSS changes in `src/index.css` to add radial background gradients, color defaults, `::selection` styling, and a `#root` min-height to improve layout. 
- Visual/theme refactor across components (`Header.jsx`, `Footer.jsx`, `Hero.jsx`, `Services.jsx`, `Work.jsx`, `About.jsx`, `Contact.jsx`) switching neutral palette to slate/cyan/emerald accents, adding translucency, backdrop blur and refined borders/shadows; also minor behavior/markup tweaks such as `img` `object-cover`, card shapes, and menu scrim styling. 
- Re-enabled the `Work` section in `src/App.jsx` and added UI elements like hero proof badges and eyebrow labels for `Services` and `Work`. 
- Updated localization files `src/i18n/locales/en/translation.json` and `src/i18n/locales/es/translation.json` with refreshed copy, new keys (`hero.proof`, `services.eyebrow`, `work.eyebrow`) and expanded commercial messaging.

### Testing
- No automated tests were added or modified for this change and no automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6349e9cd08333ac1f234316c488fd)